### PR TITLE
Run scripts with correct group

### DIFF
--- a/etc/init.d/vyos-cloudinit
+++ b/etc/init.d/vyos-cloudinit
@@ -15,5 +15,5 @@
 source $vyatta_env
 
 log_action_begin_msg "Starting vyos-cloudinit"
-${vyatta_sbindir}/vyos-cloudinit
+sg ${VYATTA_CFG_GROUP_NAME} ${vyatta_sbindir}/vyos-cloudinit
 log_action_end_msg $?

--- a/etc/init.d/vyos-ssh-key
+++ b/etc/init.d/vyos-ssh-key
@@ -15,5 +15,5 @@
 source $vyatta_env
 
 log_action_begin_msg "Starting vyos-ssh-key"
-${vyatta_sbindir}/vyos-ssh-key
+sg ${VYATTA_CFG_GROUP_NAME} ${vyatta_sbindir}/vyos-ssh-key
 log_action_end_msg $?


### PR DESCRIPTION
* Otherwise the init script will run as root group which will make the
  fuse mount get wrong permissions at /opt/vyatta/config/active