### PR TITLE
Fix default user-data URL in openstack.conf

### DIFF
--- a/sysconf/vyos-cloudinit/openstack.conf
+++ b/sysconf/vyos-cloudinit/openstack.conf
@@ -1,3 +1,3 @@
 SSH_USER="vyos"
 SSH_KEY="http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key"
-USER_DATA="http://169.254.169.254/latest/user_data"
+USER_DATA="http://169.254.169.254/latest/user-data"


### PR DESCRIPTION
The URL should contain a hyphen instead of an underscore for `user-data`.