### PR TITLE
Add Retry Support for Fetching Metadata

### DIFF
--- a/scripts/vyos-cloudinit
+++ b/scripts/vyos-cloudinit
@@ -89,7 +89,7 @@ fi
 
 if [[ "${USER_DATA}" == "http"* ]]; then
   tmpdata=$(mktemp /tmp/XXXXXX-user-data)
-  /usr/bin/curl -m 3 -sf "${USER_DATA}" -o ${tmpdata}
+  /usr/bin/curl --retry 10 --retry-delay 3 -m 3 -sf "${USER_DATA}" -o ${tmpdata}
   if [[ $? != 0 ]]; then
     echo "could not retrieve user-data from ${USER_DATA}"
     $_exit 1

--- a/scripts/vyos-ssh-key
+++ b/scripts/vyos-ssh-key
@@ -38,7 +38,7 @@ function load_key() {
 }
 
 if [[ -n "${SSH_KEY}" && "${SSH_KEY}" == "http"* ]]; then
-  /usr/bin/curl -m 3 -sf "${SSH_KEY}"
+  /usr/bin/curl --retry 10 --retry-delay 3 -m 3 -sf "${SSH_KEY}"
   if [ $? -ne 0 ]; then
     echo "could not retrieve ssh key from ${SSH_KEY}"
     $_exit 1


### PR DESCRIPTION
VyOS-CloudInit sometimes runs before the network is fully up. This results is sporadic errors attempting to communicate with the metadata service.

`retry` and `retry-delay` have been added to the `curl` commands to allow for a window where the network isn't fully up.

Fixes #5